### PR TITLE
Add allowedContent option to enable or disable content filter (ACF)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 4.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add allowedContent option to enable or disable content filter (ACF).
+  [spereverde]
 
 
 4.0.0 (2014-02-05)

--- a/src/collective/ckeditor/browser/ckeditorsettings.py
+++ b/src/collective/ckeditor/browser/ckeditorsettings.py
@@ -50,9 +50,17 @@ class ICKEditorBaseSchema(Interface):
                       "add new buttons here if needed."),
         required=False)
 
+    allowedContent = TextLine(
+        title=_(u"Allowed content"),
+        description=_(u"Option to disable/enable ACF (filtering). \
+            Set to 'true' to allow all content."),
+        default=u'null',
+        required=False)
+
     extraAllowedContent = Text(
         title=_(u"Extra Allowed Content"),
-        description=_(u"Extra filtering rules to allow content."),
+        description=_(u"Extra filtering rules to allow content. \
+            For these rules to be applied, set Allowed content to 'null'."),
         required=False)
 
     menuStyles = Text(
@@ -349,6 +357,14 @@ class CKEditorControlPanelAdapter(SchemaAdapterBase):
         self.context._updateProperty('toolbar_Custom', value)
 
     toolbar_Custom = property(get_toolbar_Custom, set_toolbar_Custom)
+
+    def get_allowedContent(self):
+        return self.context.allowedContent
+
+    def set_allowedContent(self, value):
+        self.context._updateProperty('allowedContent', value)
+
+    allowedContent = property(get_allowedContent, set_allowedContent)
 
     def get_extraAllowedContent(self):
         return self.context.extraAllowedContent

--- a/src/collective/ckeditor/browser/ckeditorview.py
+++ b/src/collective/ckeditor/browser/ckeditorview.py
@@ -227,6 +227,7 @@ class CKeditorView(BrowserView):
                 params[p] = jsProp
 
         params['toolbar_Custom'] = cke_properties.getProperty('toolbar_Custom')
+        params['allowedContent'] = cke_properties.getProperty('allowedContent')
         params['extraAllowedContent'] = cke_properties.getProperty(
             'extraAllowedContent')
         params['contentsCss'] = self.getCK_contentsCss()

--- a/src/collective/ckeditor/profiles/default/metadata.xml
+++ b/src/collective/ckeditor/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>4000</version>
+  <version>4002</version>
   <dependencies>
     <dependency>profile-collective.plonefinder:default</dependency>
     <dependency>profile-collective.quickupload:default</dependency>

--- a/src/collective/ckeditor/profiles/default/propertiestool.xml
+++ b/src/collective/ckeditor/profiles/default/propertiestool.xml
@@ -23,6 +23,7 @@
     ['Maximize', 'ShowBlocks','-','About']
 ]
   </property>
+  <property name="allowedContent" type="string">null</property>
   <property name="extraAllowedContent" type="text">
       /* Add array of allowedContent rules */
       []

--- a/src/collective/ckeditor/upgrades.zcml
+++ b/src/collective/ckeditor/upgrades.zcml
@@ -50,4 +50,17 @@
 
     </upgradeSteps>
 
+    <upgradeSteps
+        source="4001"
+        destination="4002"
+        profile="collective.ckeditor:default">
+
+        <upgradeDepends
+            title="Properties tool"
+            description="Setup new allowedContent property."
+            import_steps="propertiestool"
+            />
+
+    </upgradeSteps>
+
 </configure>


### PR DESCRIPTION
Add an option to enable or disable the CKEditor ACF (Advanced Content Filter) in the @@ckeditor-controlpanel, see http://docs.ckeditor.com/#!/guide/dev_advanced_content_filter-section-2 for more information
