### PR TITLE
Update jsregistry.xml

### DIFF
--- a/src/collective/ckeditor/profiles/default/jsregistry.xml
+++ b/src/collective/ckeditor/profiles/default/jsregistry.xml
@@ -9,5 +9,6 @@
     id="++resource++ckeditor/ckeditor.js" inline="False"/>
  <javascript cacheable="True" compression="safe" conditionalcomment=""
     cookable="True" enabled="True" expression=""
-    id="++resource++ckeditor_for_plone/ckeditor_plone.js" inline="False"/>
+    id="++resource++ckeditor_for_plone/ckeditor_plone.js" inline="False"
+    insert-after="++resource++ckeditor/ckeditor.js" />
 </object>


### PR DESCRIPTION
Explicitly stating the correct registry order is important to make sure window.CKEDITOR is defined first  (especially for sites upgraded from previous versions, for ex. with up4000)
