### PR TITLE
Added support for conditional comments (only IE) for CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ sys
 src/collective/ckeditor/browser/ckeditor
 lib
 include
+*.idea


### PR DESCRIPTION
Hello,

I was noticing that every CSS will be included into CKEditor regardless if there is a conditional statement or not. I built a JavaScript checking method, which will be applied when such a conditional statement exists.

To make this possible I needed to update how CSS entries are aggregated: Instead of a strings, there's now a intermediate dictionary (key: url, conditionalcomment). The resulting JS Code will check for each item which has a conditional comment, before adding it.

regards, Paul
