### PR TITLE
Load js only for authenticated users

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 4.3.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Load js only if you are an authenticated user.
+  [bsuttor]
 
 
 4.3.5 (2016-02-16)

--- a/src/collective/ckeditor/profiles/default/jsregistry.xml
+++ b/src/collective/ckeditor/profiles/default/jsregistry.xml
@@ -3,12 +3,12 @@
    autogroup="False" debugmode="False">
  <javascript cacheable="True" compression="safe" conditionalcomment=""
     cookable="True" enabled="True" expression=""
-    id="ckeditor_vars.js" inline="False"/>
+    id="ckeditor_vars.js" inline="False" authenticated="True"/>
  <javascript cacheable="True" compression="none" conditionalcomment=""
     cookable="True" enabled="True" expression=""
-    id="++resource++ckeditor/ckeditor.js" inline="False"/>
+    id="++resource++ckeditor/ckeditor.js" inline="False" authenticated="True"/>
  <javascript cacheable="True" compression="safe" conditionalcomment=""
     cookable="True" enabled="True" expression=""
     id="++resource++ckeditor_for_plone/ckeditor_plone.js" inline="False"
-    insert-after="++resource++ckeditor/ckeditor.js" />
+    insert-after="++resource++ckeditor/ckeditor.js" authenticated="True"/>
 </object>


### PR DESCRIPTION
Size of js is more than 1 Mb, so it's better to not upload it if you are anonymous.

This PR should close https://github.com/collective/collective.ckeditor/issues/50