### PR TITLE
AjaxSave plugin, set ajax query async:false so it is possible to define a afterExecCommand event handler.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,9 +11,9 @@ Changelog
 - AjaxSave plugin, add message when nothing saved because nothing changed
   (Content already saved (nothing changed).)
   [gbastien]
-- AjaxSave plugin, set ajax query async:false so it is possible to define
-  a afterExecCommand event handler.
-  [gbastien]
+- AjaxSave plugin, added `async:true` attribute so it is possible to set it
+  to `async:false` and make sure content is saved before continuing.
+  [gotcha, gbastien]
 
 4.9.0 (2019-09-12)
 ------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,7 +11,9 @@ Changelog
 - AjaxSave plugin, add message when nothing saved because nothing changed
   (Content already saved (nothing changed).)
   [gbastien]
-
+- AjaxSave plugin, set ajax query async:false so it is possible to define
+  a afterExecCommand event handler.
+  [gbastien]
 
 4.9.0 (2019-09-12)
 ------------------

--- a/src/collective/ckeditor/browser/ajaxsave/plugin.js
+++ b/src/collective/ckeditor/browser/ajaxsave/plugin.js
@@ -41,6 +41,7 @@
             url: editor.config.ajaxsave_url,
             type: 'POST',
             data: data,
+            async: false,
             success: function(data){
                 editor.resetDirty();
                 showMessage(editor, 'Content saved.');

--- a/src/collective/ckeditor/browser/ajaxsave/plugin.js
+++ b/src/collective/ckeditor/browser/ajaxsave/plugin.js
@@ -25,6 +25,7 @@
         };
     };
     var saveCmd = {
+        async : true,
         modes : { wysiwyg:1, source:1 },
         exec : function( editor ) {
         if (!editor.checkDirty()) {
@@ -41,7 +42,7 @@
             url: editor.config.ajaxsave_url,
             type: 'POST',
             data: data,
-            async: false,
+            async: this.async,
             success: function(data){
                 editor.resetDirty();
                 showMessage(editor, 'Content saved.');


### PR DESCRIPTION
Hi @gotcha 

as stated by https://github.com/ckeditor/ckeditor4/blob/1aa21195bda3e4cfb4f19fa70d5a285b56965d70/core/editor.js#L985 a afterCommandExec is triggered automatically when the command finished, but to have a synchronous behaviour, so to be sure that save is finished, we need to ajax query to be async:false or execCommand returns before and following code does not get the saved content...

Could you please advice and merge if ok?

Thank you!

Gauthier